### PR TITLE
[Feature]: Encode http body in JSON or URL

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,9 @@ name: Swift
 on:
   push:
     branches: [ "main" ]
-    
+  pull_request:
+    branches: [ "main" ]
+
 jobs:
   iOS16: 
     runs-on: macos-latest

--- a/Examples/Examples/ViewController.swift
+++ b/Examples/Examples/ViewController.swift
@@ -15,6 +15,9 @@ struct HttpBinResponseModel: Codable {
     let origin:  String
 }
 
+struct HttpReqResponseModel: Codable {
+    let success: String
+}
 
 // MARK: - Headers
 struct Headers: Codable {

--- a/Sources/Enum/Encoding.swift
+++ b/Sources/Enum/Encoding.swift
@@ -1,0 +1,15 @@
+//
+//  File.swift
+//  
+//
+//  Created by 이유돈 on 2023/02/23.
+//
+
+import Foundation
+
+public enum Encoding: String {
+    // default http encoding is url decoded
+    case parameterUrlEncoded
+    case bodyJsonEncoded
+    case bodyURLEncoded
+}

--- a/Sources/Enum/SNError.swift
+++ b/Sources/Enum/SNError.swift
@@ -10,6 +10,10 @@ import Foundation
 public enum SNError: Error {
     case invalidURL(url: URLEnable)
     case invalidHttpResponse(statusCode: Int)
+    
+    public enum EncodingFailure: Error {
+        case contentTypeInvalid(contentType: String, encoding: Encoding)
+    }
 }
 
 extension SNError: LocalizedError {
@@ -19,6 +23,15 @@ extension SNError: LocalizedError {
             return "URL is not valid: \(url)"
         case .invalidHttpResponse(let statusCode):
             return "Http Request is not valid. Error Status code is \(statusCode)"
+        }
+    }
+}
+
+extension SNError.EncodingFailure {
+    public var errorDescription: String? {
+        switch self {
+        case .contentTypeInvalid(let contentType, let encoding):
+            return "Content-Type header \(contentType) in an HTTP request did not match the encoding mode \(encoding.rawValue)"
         }
     }
 }

--- a/Sources/SwiftNetzy.swift
+++ b/Sources/SwiftNetzy.swift
@@ -9,26 +9,17 @@ import Foundation
 
 public final class SwiftNetzy {
     
-    public static func request<T: Codable>(_ type: T.Type, _ urlEnable: URLEnable, method: HTTPMethod, headers: [String: String] = [:], params: [String: String] = [:], body: [String: String] = [:]) async throws -> T {
+    public static func request<T: Codable>(_ type: T.Type, _ urlEnable: URLEnable, method: HTTPMethod, headers: [String: String] = [:], params: [String: String] = [:], body: [String: String] = [:], encoding: Encoding = .parameterUrlEncoded) async throws -> T {
         
         let url = try urlEnable.toURL()
         
         var urlQueries = URLComponents(url: url, resolvingAgainstBaseURL: false)
         urlQueries?.queryItems = params.map { URLQueryItem(name: $0.key, value: $0.value) }
         
-        
         guard let urlQueries = urlQueries else { throw SNError.invalidURL(url: url) }
         let urlRequestURL = try urlQueries.toURL()
-        var urlRequest = URLRequest(url: urlRequestURL)
-        urlRequest.httpMethod = method.rawValue
         
-        if !body.isEmpty {
-            let encodedBody = try JSONEncoder().encode(body)
-            urlRequest.httpBody = encodedBody
-            
-        }
-        
-        urlRequest.allHTTPHeaderFields = headers
+        let urlRequest = try self.makeURLRequest(url: urlRequestURL, method: method, headers: headers, body: body, encoding: encoding)
         
         let (data, response) = try await {
             if #available(iOS 15, *) {
@@ -48,15 +39,52 @@ public final class SwiftNetzy {
     }
     
     static func requestURLSessionDataEscaping(for urlRequest: URLRequest) async throws -> (Data, URLResponse) {
-       try await withCheckedThrowingContinuation({ continuation in
-         URLSession.shared.dataTask(with: urlRequest) { data, response, error in
-           if let error = error {
-             continuation.resume(throwing: error)
-           }
-           if let data = data, let response = response {
-             continuation.resume(returning: (data, response))
-           }
-         }.resume()
-       })
-     }
+        try await withCheckedThrowingContinuation({ continuation in
+            URLSession.shared.dataTask(with: urlRequest) { data, response, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                }
+                if let data = data, let response = response {
+                    continuation.resume(returning: (data, response))
+                }
+            }.resume()
+        })
+    }
+    
+    static func makeURLRequest(url: URL, method: HTTPMethod, headers: [String: String], body: [String: String],  encoding: Encoding) throws -> URLRequest {
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = method.rawValue
+        urlRequest.allHTTPHeaderFields = headers
+        
+        let httpMethods: [HTTPMethod] = [.put, .post]
+        
+        if !httpMethods.contains(method) || body.isEmpty {
+            return urlRequest
+        }
+        
+        switch encoding {
+        case .bodyJsonEncoded:
+            if headers["Content-Type"] == "application/json" {
+                let encodedBody = try JSONEncoder().encode(body)
+                urlRequest.httpBody = encodedBody
+            } else {
+                throw SNError.EncodingFailure.contentTypeInvalid(contentType: headers["Content-Type"] ?? "Content Type", encoding: encoding)
+            }
+        case .bodyURLEncoded:
+            if headers["Content-Type"] == "application/x-www-form-urlencoded" || headers["Content-Type"] == "application/x-www-form-urlencoded; charset=utf-8" {
+                var requestBodyComponents = URLComponents()
+                requestBodyComponents.queryItems = body.map { URLQueryItem(name: $0, value: $1) }
+                urlRequest.httpBody = requestBodyComponents.query?.data(using: .utf8)
+            } else {
+                throw SNError.EncodingFailure.contentTypeInvalid(contentType: headers["Content-Type"] ?? "Content Type", encoding: encoding)
+            }
+        default:
+            break
+        }
+        
+        return urlRequest
+    }
 }
+
+
+

--- a/Tests/SwiftNetzyTests/SwiftNetzyTests.swift
+++ b/Tests/SwiftNetzyTests/SwiftNetzyTests.swift
@@ -5,6 +5,10 @@ struct HttpBinResponseModel: Codable {
     let url: String
 }
 
+struct HttpReqResponseModel: Codable {
+    let success: String
+}
+
 final class SwiftNetzyTests: XCTestCase {
 
     func testGetMethod() async throws {
@@ -32,4 +36,29 @@ final class SwiftNetzyTests: XCTestCase {
         
         XCTAssertEqual(deleteResponse.url, "https://httpbin.org/delete")
     }
+    
+    func testPostMethodURLEncodedTest() async throws {
+        let headers = ["Content-Type": "application/x-www-form-urlencoded"]
+        let bodyInfo: [String: String] = [
+            "Id": "12345",
+            "Customer": "John Smith",
+            "Quantity": "1",
+            "Price": "10.00"
+          ]
+        let postResponse = try await SwiftNetzy.request(HttpReqResponseModel.self, "https://reqbin.com/echo/post/json", method: .post, headers: headers, body: bodyInfo, encoding: .bodyURLEncoded)
+        XCTAssertEqual(postResponse.success, "true")
+    }
+    
+    func testPostMethodJsonEncoded() async throws {
+        let headers = ["Content-Type": "application/json"]
+        let bodyInfo: [String: String] = [
+            "Id": "12345",
+            "Customer": "John Smith",
+            "Quantity": "1",
+            "Price": "10.00"
+          ]
+        let postResponse = try await SwiftNetzy.request(HttpReqResponseModel.self, "https://reqbin.com/echo/post/json", method: .post, headers: headers, body: bodyInfo, encoding: .bodyJsonEncoded)
+        XCTAssertEqual(postResponse.success, "true")
+    }
+    
 }


### PR DESCRIPTION
## Related Issue
<!-- write related Issue number  -->
- close #1 

## Background
<!-- Write down the basis of implementation -->
The two most frequently used Content Types in HTTP requests or responses:

1. application/json
- JSON is a standard text-based format for representing structured data based on JavaScript object syntax.

2. application/x-www-form-urlencoded
- the keys and values are encoded in key-value tuples separated by '&', with a '=' between the key and the value
application/x-www-form-urlencoded is a MIME type for data submitted through HTML forms. 

https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/JSON
https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST 
